### PR TITLE
fix field name for signature sources

### DIFF
--- a/src/components/routes/admin/service_detail/source_dialog.tsx
+++ b/src/components/routes/admin/service_detail/source_dialog.tsx
@@ -145,7 +145,7 @@ const WrappedSourceDialog = ({ open, setOpen, source, onSave }: SourceDialogProp
                   <Classification
                     c12n={tempSource.default_classification}
                     type="picker"
-                    setClassification={value => handleValueChange('classification', value)}
+                    setClassification={value => handleValueChange('default_classification', value)}
                   />
                 </Grid>
               )}


### PR DESCRIPTION
Prior code adds a "classification" field which doesn't exist in the ODM for signature sources, assuming this is a typo.