### PR TITLE
Renaming process keys to be synced with SandboxOntology format

### DIFF
--- a/src/components/visual/ResultCard/result_section.tsx
+++ b/src/components/visual/ResultCard/result_section.tsx
@@ -230,7 +230,7 @@ const ProcessTreeItem = ({ process }) => {
 
   return (
     <TreeItem
-      nodeId={process.process_pid.toString()}
+      nodeId={process.pid.toString()}
       classes={{
         root: classes.root
       }}
@@ -259,11 +259,11 @@ const ProcessTreeItem = ({ process }) => {
               borderRadius: '4px 0px 0px 4px'
             }}
           >
-            {process.process_pid}
+            {process.pid}
           </div>
           <div style={{ padding: '5px', flexGrow: 1, wordBreak: 'break-word' }}>
             <div style={{ paddingBottom: '5px' }}>
-              <b>{process.process_name}</b>
+              <b>{process.image}</b>
             </div>
             <div>
               <samp>
@@ -304,13 +304,13 @@ const ProcessTreeBody = ({ body }) => {
 
     // Auto-expand first two levels
     data.forEach(process => {
-      if (process.process_pid !== undefined && process.process_pid !== null) {
-        expanded.push(process.process_pid.toString());
+      if (process.pid !== undefined && process.pid !== null) {
+        expanded.push(process.pid.toString());
       }
       if (process.children !== undefined && process.children !== null && process.children.length !== 0) {
         process.children.forEach(subprocess => {
-          if (subprocess.process_pid !== undefined && subprocess.process_pid !== null) {
-            expanded.push(subprocess.process_pid.toString());
+          if (subprocess.pid !== undefined && subprocess.pid !== null) {
+            expanded.push(subprocess.pid.toString());
           }
         });
       }


### PR DESCRIPTION
The keys `pid` and `image` are synonymous with all Events in the `dynamic_service_helper.py` (https://github.com/CybercentreCanada/assemblyline-v4-service/blob/b9940eab251f4f0aff08399a37c1b429b1812bc1/assemblyline_v4_service/common/dynamic_service_helper.py#L12). Therefore, updating UI to reflect this change.