### PR TITLE
Temporary drawer close on page change (dev)

### DIFF
--- a/src/components/routes/routes.tsx
+++ b/src/components/routes/routes.tsx
@@ -1,4 +1,5 @@
 import useALContext from 'components/hooks/useALContext';
+import useDrawer from 'components/hooks/useDrawer';
 import ForbiddenPage from 'components/routes/403';
 import NotFoundPage from 'components/routes/404_dl';
 import Account from 'components/routes/account';
@@ -49,6 +50,7 @@ const APP_NAME = 'AL4';
 function RouteActions() {
   const { pathname } = useLocation();
   const [oldID, setOldID] = useState(null);
+  const { closeTemporaryDrawer } = useDrawer();
 
   useEffect(() => {
     // Scroll to top
@@ -65,6 +67,8 @@ function RouteActions() {
     document.title = `${APP_NAME} | ${
       currentLocation ? currentLocation.charAt(0).toUpperCase() + currentLocation.slice(1) : 'Submit'
     }`;
+
+    closeTemporaryDrawer();
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pathname]);

--- a/src/components/visual/DrawerProvider.tsx
+++ b/src/components/visual/DrawerProvider.tsx
@@ -53,6 +53,7 @@ const useStyles = makeStyles(theme => ({
 
 export type DrawerContextProps = {
   closeGlobalDrawer: () => void;
+  closeTemporaryDrawer: () => void;
   setGlobalDrawer: (elements: React.ReactElement<any>) => void;
   globalDrawer: React.ReactElement<any>;
 };
@@ -76,11 +77,15 @@ function DrawerProvider(props: DrawerProviderProps) {
   const closeGlobalDrawer = () => {
     setGlobalDrawer(null);
   };
+  const closeTemporaryDrawer = () => {
+    if (!isXL) setGlobalDrawer(null);
+  };
 
   return (
     <DrawerContext.Provider
       value={{
         closeGlobalDrawer,
+        closeTemporaryDrawer,
         setGlobalDrawer,
         globalDrawer
       }}

--- a/src/components/visual/SearchResult/results.tsx
+++ b/src/components/visual/SearchResult/results.tsx
@@ -3,6 +3,7 @@ import Paper from '@material-ui/core/Paper';
 import TableContainer from '@material-ui/core/TableContainer';
 import { AlertTitle, Skeleton } from '@material-ui/lab';
 import useALContext from 'components/hooks/useALContext';
+import useDrawer from 'components/hooks/useDrawer';
 import Classification from 'components/visual/Classification';
 import Verdict from 'components/visual/Verdict';
 import 'moment/locale/fr';
@@ -48,6 +49,7 @@ type ResultsTableProps = {
 const WrappedResultsTable: React.FC<ResultsTableProps> = ({ resultResults, allowSort = true }) => {
   const { t, i18n } = useTranslation(['search']);
   const { c12nDef } = useALContext();
+  const { closeGlobalDrawer } = useDrawer();
 
   return resultResults ? (
     resultResults.total !== 0 ? (
@@ -80,6 +82,7 @@ const WrappedResultsTable: React.FC<ResultsTableProps> = ({ resultResults, allow
                 key={result.id}
                 component={Link}
                 to={`/file/detail/${result.id.substring(0, 64)}`}
+                onClick={closeGlobalDrawer}
                 hover
                 style={{ textDecoration: 'none' }}
               >

--- a/src/components/visual/SearchResult/results.tsx
+++ b/src/components/visual/SearchResult/results.tsx
@@ -3,7 +3,6 @@ import Paper from '@material-ui/core/Paper';
 import TableContainer from '@material-ui/core/TableContainer';
 import { AlertTitle, Skeleton } from '@material-ui/lab';
 import useALContext from 'components/hooks/useALContext';
-import useDrawer from 'components/hooks/useDrawer';
 import Classification from 'components/visual/Classification';
 import Verdict from 'components/visual/Verdict';
 import 'moment/locale/fr';
@@ -49,7 +48,6 @@ type ResultsTableProps = {
 const WrappedResultsTable: React.FC<ResultsTableProps> = ({ resultResults, allowSort = true }) => {
   const { t, i18n } = useTranslation(['search']);
   const { c12nDef } = useALContext();
-  const { closeTemporaryDrawer } = useDrawer();
 
   return resultResults ? (
     resultResults.total !== 0 ? (
@@ -82,7 +80,6 @@ const WrappedResultsTable: React.FC<ResultsTableProps> = ({ resultResults, allow
                 key={result.id}
                 component={Link}
                 to={`/file/detail/${result.id.substring(0, 64)}`}
-                onClick={closeTemporaryDrawer}
                 hover
                 style={{ textDecoration: 'none' }}
               >

--- a/src/components/visual/SearchResult/results.tsx
+++ b/src/components/visual/SearchResult/results.tsx
@@ -49,7 +49,7 @@ type ResultsTableProps = {
 const WrappedResultsTable: React.FC<ResultsTableProps> = ({ resultResults, allowSort = true }) => {
   const { t, i18n } = useTranslation(['search']);
   const { c12nDef } = useALContext();
-  const { closeGlobalDrawer } = useDrawer();
+  const { closeTemporaryDrawer } = useDrawer();
 
   return resultResults ? (
     resultResults.total !== 0 ? (
@@ -82,7 +82,7 @@ const WrappedResultsTable: React.FC<ResultsTableProps> = ({ resultResults, allow
                 key={result.id}
                 component={Link}
                 to={`/file/detail/${result.id.substring(0, 64)}`}
-                onClick={closeGlobalDrawer}
+                onClick={closeTemporaryDrawer}
                 hover
                 style={{ textDecoration: 'none' }}
               >


### PR DESCRIPTION
On the "Heuristics Details" drawer section, the drawer now closes when you click on a file in the "Last 10 hits" table. Fixed the DrawerProvider by creating the "closeTemporaryDrawer" method that only closes the Drawer if it is in the 'temporary' variant.