### PR TITLE
External Links (dev): Fixed an issue with ChipList not being able to be clicked.

### DIFF
--- a/src/components/routes/alerts/alert-details.tsx
+++ b/src/components/routes/alerts/alert-details.tsx
@@ -24,10 +24,12 @@ import useALContext from 'components/hooks/useALContext';
 import useMyAPI from 'components/hooks/useMyAPI';
 import { CustomUser } from 'components/hooks/useMyUser';
 import { AlertItem, DetailedItem, detailedItemCompare } from 'components/routes/alerts/hooks/useAlerts';
+import { ActionableChipList } from 'components/visual/ActionableChipList';
+import { ActionableCustomChipProps } from 'components/visual/ActionableCustomChip';
 import ActionableText from 'components/visual/ActionableText';
-import { ChipList, ChipSkeleton, ChipSkeletonInline } from 'components/visual/ChipList';
+import { ChipSkeleton, ChipSkeletonInline } from 'components/visual/ChipList';
 import Classification from 'components/visual/Classification';
-import CustomChip, { CustomChipProps } from 'components/visual/CustomChip';
+import CustomChip from 'components/visual/CustomChip';
 import Verdict from 'components/visual/Verdict';
 import VerdictBar from 'components/visual/VerdictBar';
 import { verdictToColor } from 'helpers/utils';
@@ -76,22 +78,25 @@ const SkeletonInline = () => <Skeleton style={{ display: 'inline-block', width: 
 
 type AutoHideChipListState = {
   showExtra: boolean;
-  fullChipList: CustomChipProps[];
+  fullChipList: ActionableCustomChipProps[];
 };
 
 const WrappedAutoHideChipList: React.FC<AutoHideChipListProps> = ({ items, type = null }) => {
   const { t } = useTranslation();
   const [state, setState] = useState<AutoHideChipListState | null>(null);
-  const [shownChips, setShownChips] = useState<CustomChipProps[]>([]);
+  const [shownChips, setShownChips] = useState<ActionableCustomChipProps[]>([]);
 
   useEffect(() => {
-    const fullChipList = items.sort(detailedItemCompare).map(item => ({
-      category: 'tag',
-      data_type: type,
-      label: item.subtype ? `${item.value} - ${item.subtype}` : item.value,
-      variant: 'outlined' as 'outlined',
-      color: verdictToColor(item.verdict)
-    }));
+    const fullChipList = items.sort(detailedItemCompare).map(
+      item =>
+        ({
+          category: 'tag',
+          data_type: type,
+          label: item.subtype ? `${item.value} - ${item.subtype}` : item.value,
+          variant: 'outlined',
+          color: verdictToColor(item.verdict)
+        } as ActionableCustomChipProps)
+    );
     const showExtra = items.length <= TARGET_RESULT_COUNT;
 
     setState({ showExtra, fullChipList });
@@ -109,7 +114,7 @@ const WrappedAutoHideChipList: React.FC<AutoHideChipListProps> = ({ items, type 
 
   return (
     <>
-      <ChipList items={shownChips} />
+      <ActionableChipList items={shownChips} />
       {state && !state.showExtra && (
         <Tooltip title={t('more')}>
           <IconButton size="small" onClick={() => setState({ ...state, showExtra: true })} style={{ padding: 0 }}>
@@ -361,7 +366,7 @@ const WrappedAlertDetails: React.FC<AlertDetailsProps> = ({ id, alert }) => {
                 <Typography className={classes.sectionTitle}>{t('label')}</Typography>
                 <Divider />
                 <div className={classes.sectionContent}>
-                  <ChipList items={item ? item.label.map(label => ({ label, variant: 'outlined' })) : null} />
+                  <ActionableChipList items={item ? item.label.map(label => ({ label, variant: 'outlined' })) : null} />
                 </div>
               </div>
             </div>
@@ -592,7 +597,9 @@ const WrappedAlertDetails: React.FC<AlertDetailsProps> = ({ id, alert }) => {
                       {item && item.al.detailed ? (
                         <AutoHideChipList items={item.al.detailed.attrib} />
                       ) : (
-                        <ChipList items={item ? item.al.attrib.map(label => ({ label, variant: 'outlined' })) : null} />
+                        <ActionableChipList
+                          items={item ? item.al.attrib.map(label => ({ label, variant: 'outlined' })) : null}
+                        />
                       )}
                     </div>
                   </Grid>
@@ -610,7 +617,9 @@ const WrappedAlertDetails: React.FC<AlertDetailsProps> = ({ id, alert }) => {
                       {item && item.al.detailed ? (
                         <AutoHideChipList items={item.al.detailed.av} type="av.virus_name" />
                       ) : (
-                        <ChipList items={item ? item.al.av.map(label => ({ label, variant: 'outlined' })) : null} />
+                        <ActionableChipList
+                          items={item ? item.al.av.map(label => ({ label, variant: 'outlined' })) : null}
+                        />
                       )}
                     </div>
                   </Grid>
@@ -637,7 +646,7 @@ const WrappedAlertDetails: React.FC<AlertDetailsProps> = ({ id, alert }) => {
                                 type="network.dynamic.ip"
                               />
                             ) : (
-                              <ChipList
+                              <ActionableChipList
                                 items={
                                   item
                                     ? item.al.ip_dynamic.map(label => ({
@@ -661,7 +670,7 @@ const WrappedAlertDetails: React.FC<AlertDetailsProps> = ({ id, alert }) => {
                                 type="network.static.ip"
                               />
                             ) : (
-                              <ChipList
+                              <ActionableChipList
                                 items={
                                   item
                                     ? item.al.ip_static.map(label => ({
@@ -702,7 +711,7 @@ const WrappedAlertDetails: React.FC<AlertDetailsProps> = ({ id, alert }) => {
                                 type="network.dynamic.domain"
                               />
                             ) : (
-                              <ChipList
+                              <ActionableChipList
                                 items={
                                   item
                                     ? item.al.domain_dynamic.map(label => ({
@@ -728,7 +737,7 @@ const WrappedAlertDetails: React.FC<AlertDetailsProps> = ({ id, alert }) => {
                                 type="network.static.domain"
                               />
                             ) : (
-                              <ChipList
+                              <ActionableChipList
                                 items={
                                   item
                                     ? item.al.domain_static.map(label => ({
@@ -767,7 +776,7 @@ const WrappedAlertDetails: React.FC<AlertDetailsProps> = ({ id, alert }) => {
                                 type="network.dynamic.uri"
                               />
                             ) : (
-                              <ChipList
+                              <ActionableChipList
                                 items={
                                   item
                                     ? item.al.uri_dynamic.map(label => ({
@@ -791,7 +800,7 @@ const WrappedAlertDetails: React.FC<AlertDetailsProps> = ({ id, alert }) => {
                                 type="network.static.uri"
                               />
                             ) : (
-                              <ChipList
+                              <ActionableChipList
                                 items={
                                   item
                                     ? item.al.uri_static.map(label => ({
@@ -821,7 +830,7 @@ const WrappedAlertDetails: React.FC<AlertDetailsProps> = ({ id, alert }) => {
                       {item && item.al.detailed ? (
                         <AutoHideChipList items={item.al.detailed.heuristic} />
                       ) : (
-                        <ChipList
+                        <ActionableChipList
                           items={item ? item.heuristic.name.map(label => ({ label, variant: 'outlined' })) : null}
                         />
                       )}
@@ -841,7 +850,7 @@ const WrappedAlertDetails: React.FC<AlertDetailsProps> = ({ id, alert }) => {
                       {item && item.al.detailed ? (
                         <AutoHideChipList items={item.al.detailed.behavior} type="file.behavior" />
                       ) : (
-                        <ChipList
+                        <ActionableChipList
                           items={item ? item.al.behavior.map(label => ({ label, variant: 'outlined' })) : null}
                         />
                       )}
@@ -861,7 +870,9 @@ const WrappedAlertDetails: React.FC<AlertDetailsProps> = ({ id, alert }) => {
                       {item && item.al.detailed ? (
                         <AutoHideChipList items={item.al.detailed.yara} type="file.rule.yara" />
                       ) : (
-                        <ChipList items={item ? item.al.yara.map(label => ({ label, variant: 'outlined' })) : null} />
+                        <ActionableChipList
+                          items={item ? item.al.yara.map(label => ({ label, variant: 'outlined' })) : null}
+                        />
                       )}
                     </div>
                   </Grid>
@@ -884,7 +895,7 @@ const WrappedAlertDetails: React.FC<AlertDetailsProps> = ({ id, alert }) => {
                           {item && item.al.detailed ? (
                             <AutoHideChipList items={item.al.detailed.attack_category} />
                           ) : (
-                            <ChipList
+                            <ActionableChipList
                               items={item ? item.attack.category.map(label => ({ label, variant: 'outlined' })) : null}
                             />
                           )}
@@ -896,7 +907,7 @@ const WrappedAlertDetails: React.FC<AlertDetailsProps> = ({ id, alert }) => {
                           {item && item.al.detailed ? (
                             <AutoHideChipList items={item.al.detailed.attack_pattern} />
                           ) : (
-                            <ChipList
+                            <ActionableChipList
                               items={item ? item.attack.pattern.map(label => ({ label, variant: 'outlined' })) : null}
                             />
                           )}

--- a/src/components/routes/alerts/alert-events.tsx
+++ b/src/components/routes/alerts/alert-events.tsx
@@ -14,7 +14,7 @@ import {
   Typography,
   useTheme
 } from '@mui/material';
-import { ChipList } from 'components/visual/ChipList';
+import { ActionableChipList } from 'components/visual/ActionableChipList';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { HiOutlineExternalLink } from 'react-icons/hi';
@@ -89,7 +89,7 @@ const WrappedAlertEventsTable = ({ alert, viewHistory, setViewHistory }) => {
                           <TableCell>{event.status ? <AlertStatus name={event.status} /> : null}</TableCell>
                           <TableCell width="40%">
                             {event.labels ? (
-                              <ChipList
+                              <ActionableChipList
                                 items={event.labels.map(label => ({ label, variant: 'outlined' }))}
                                 wrap={false}
                               />

--- a/src/components/routes/alerts/alert-list-item.tsx
+++ b/src/components/routes/alerts/alert-list-item.tsx
@@ -1,11 +1,11 @@
-import { Grid, Tooltip, useTheme } from '@mui/material';
 import BugReportOutlinedIcon from '@mui/icons-material/BugReportOutlined';
 import GroupOutlinedIcon from '@mui/icons-material/GroupOutlined';
 import PersonOutlineOutlinedIcon from '@mui/icons-material/PersonOutlineOutlined';
 import VerifiedUserOutlinedIcon from '@mui/icons-material/VerifiedUserOutlined';
+import { Grid, Tooltip, useTheme } from '@mui/material';
 import useALContext from 'components/hooks/useALContext';
 import { AlertItem, detailedItemCompare } from 'components/routes/alerts/hooks/useAlerts';
-import { ChipList } from 'components/visual/ChipList';
+import { ActionableChipList } from 'components/visual/ActionableChipList';
 import CustomChip from 'components/visual/CustomChip';
 import Verdict from 'components/visual/Verdict';
 import { verdictToColor } from 'helpers/utils';
@@ -132,7 +132,7 @@ const WrappedAlertListItem: React.FC<AlertListItemProps> = ({ item }) => {
           </Grid>
         </Grid>
         <Grid item xs={12} md={6}>
-          <ChipList
+          <ActionableChipList
             items={item.label
               .sort()
               .map(label => ({

--- a/src/components/routes/alerts/alerts-filters-favorites.tsx
+++ b/src/components/routes/alerts/alerts-filters-favorites.tsx
@@ -3,7 +3,7 @@ import useAppUser from 'commons/components/app/hooks/useAppUser';
 import useALContext from 'components/hooks/useALContext';
 import useMySnackbar from 'components/hooks/useMySnackbar';
 import { CustomUser } from 'components/hooks/useMyUser';
-import { ChipList } from 'components/visual/ChipList';
+import { ActionableChipList } from 'components/visual/ActionableChipList';
 import Classification from 'components/visual/Classification';
 import ConfirmationDialog from 'components/visual/ConfirmationDialog';
 import React, { useState } from 'react';
@@ -187,7 +187,7 @@ const AlertsFiltersFavorites: React.FC<AlertsFiltersFavoritesProps> = ({
       <Typography variant="h6">{t('yourfavorites')}</Typography>
       <Divider />
       <div style={{ marginTop: theme.spacing(1), marginBottom: theme.spacing(4) }}>
-        <ChipList
+        <ActionableChipList
           items={userFavorites.map(f => ({
             size: 'medium',
             variant: 'outlined',
@@ -203,7 +203,7 @@ const AlertsFiltersFavorites: React.FC<AlertsFiltersFavoritesProps> = ({
       <Typography variant="h6">{t('globalfavorites')}</Typography>
       <Divider />
       <div style={{ marginTop: theme.spacing(1) }}>
-        <ChipList
+        <ActionableChipList
           items={globalFavorites.map(f => ({
             size: 'medium',
             variant: 'outlined',

--- a/src/components/routes/alerts/alerts-filters-selected.tsx
+++ b/src/components/routes/alerts/alerts-filters-selected.tsx
@@ -1,4 +1,4 @@
-import { ChipList } from 'components/visual/ChipList';
+import { ActionableChipList } from 'components/visual/ActionableChipList';
 import SearchQuery, { SearchFilter, SearchQueryFilters } from 'components/visual/SearchBar/search-query';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -60,7 +60,7 @@ const AlertsFiltersSelected: React.FC<AlertFiltersSelectedProps> = ({
       <div>
         {query && !hideQuery && (
           <div style={{ display: 'inline-block' }}>
-            <ChipList
+            <ActionableChipList
               items={[query].map(v => ({
                 variant: 'outlined',
                 label: `${v}`,
@@ -71,7 +71,7 @@ const AlertsFiltersSelected: React.FC<AlertFiltersSelectedProps> = ({
         )}
         {filters && filters.tc && (
           <div style={{ display: 'inline-block' }}>
-            <ChipList
+            <ActionableChipList
               items={[filters.tc].map(v => ({
                 variant: 'outlined',
                 label: `${t('tc')}=${v}`,
@@ -82,7 +82,7 @@ const AlertsFiltersSelected: React.FC<AlertFiltersSelectedProps> = ({
         )}
         {filters && filters.groupBy && !hideGroupBy && (
           <div style={{ display: 'inline-block' }}>
-            <ChipList
+            <ActionableChipList
               items={[filters.groupBy].map(v => ({
                 variant: 'outlined',
                 label: `${t('groupBy')}=${v}`,
@@ -93,7 +93,7 @@ const AlertsFiltersSelected: React.FC<AlertFiltersSelectedProps> = ({
         )}
         {filters && filters.statuses.length !== 0 && (
           <div style={{ display: 'inline-block' }}>
-            <ChipList
+            <ActionableChipList
               items={filters.statuses.map(v => ({
                 variant: 'outlined',
                 label: v.value,
@@ -104,7 +104,7 @@ const AlertsFiltersSelected: React.FC<AlertFiltersSelectedProps> = ({
         )}
         {filters && filters.priorities.length !== 0 && (
           <div style={{ display: 'inline-block' }}>
-            <ChipList
+            <ActionableChipList
               items={filters.priorities.map(v => ({
                 variant: 'outlined',
                 label: v.value,
@@ -115,7 +115,7 @@ const AlertsFiltersSelected: React.FC<AlertFiltersSelectedProps> = ({
         )}
         {filters && filters.labels.length !== 0 && (
           <div style={{ display: 'inline-block' }}>
-            <ChipList
+            <ActionableChipList
               items={filters.labels.map(v => ({
                 variant: 'outlined',
                 label: v.value,
@@ -126,7 +126,7 @@ const AlertsFiltersSelected: React.FC<AlertFiltersSelectedProps> = ({
         )}
         {filters && filters.queries.length !== 0 && (
           <div style={{ display: 'inline-block' }}>
-            <ChipList
+            <ActionableChipList
               items={filters.queries.map(v => ({
                 variant: 'outlined',
                 label: v.value,

--- a/src/components/visual/ActionableChipList.tsx
+++ b/src/components/visual/ActionableChipList.tsx
@@ -1,7 +1,7 @@
 import { Skeleton, Theme, useTheme } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
-import CustomChip, { CustomChipProps } from 'components/visual/CustomChip';
 import React from 'react';
+import ActionableCustomChip, { ActionableCustomChipProps } from './ActionableCustomChip';
 
 const useStyles = makeStyles((theme: Theme) => ({
   chiplist: {
@@ -18,8 +18,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   }
 }));
 
-type ChipListProps = {
-  items: CustomChipProps[];
+type ActionableChipListProps = {
+  items: ActionableCustomChipProps[];
+  wrap?: boolean;
 };
 
 const ChipSkeleton = () => (
@@ -35,7 +36,7 @@ const ChipSkeletonInline = () => (
   />
 );
 
-const ChipList: React.FC<ChipListProps> = ({ items }) => {
+const ActionableChipList: React.FC<ActionableChipListProps> = ({ items, wrap = true }) => {
   const theme = useTheme();
   const classes = useStyles();
   return (
@@ -43,7 +44,7 @@ const ChipList: React.FC<ChipListProps> = ({ items }) => {
       {items
         ? items.map((cp, i) => (
             <li key={`chiplist-${i}`}>
-              <CustomChip size="small" className={classes.chip} wrap {...cp} />
+              <ActionableCustomChip size="small" className={classes.chip} wrap={wrap} {...cp} />
             </li>
           ))
         : [...Array(3)].map((k, i) => (
@@ -64,4 +65,4 @@ const ChipList: React.FC<ChipListProps> = ({ items }) => {
   );
 };
 
-export { ChipList, ChipSkeleton, ChipSkeletonInline };
+export { ActionableChipList, ChipSkeleton, ChipSkeletonInline };

--- a/src/components/visual/ActionableCustomChip.tsx
+++ b/src/components/visual/ActionableCustomChip.tsx
@@ -4,11 +4,19 @@ import CustomChip, { CustomChipProps } from './CustomChip';
 import ExternalLinks from './ExternalLookup/ExternalLinks';
 import { useSearchTagExternal } from './ExternalLookup/useExternalLookup';
 
-export interface ActionableCustomChipProps extends CustomChipProps {
+// export interface ActionableCustomChipProps extends CustomChipProps {
+//   data_type?: string;
+//   category?: 'hash' | 'metadata' | 'tag';
+//   classification?: string;
+//   label?: string;
+// }
+
+export type ActionableCustomChipProps = CustomChipProps & {
   data_type?: string;
   category?: 'hash' | 'metadata' | 'tag';
   classification?: string;
-}
+  label?: string;
+};
 
 const initialMenuState = {
   mouseX: null,
@@ -20,6 +28,7 @@ const WrappedActionableCustomChip: React.FC<ActionableCustomChipProps> = ({
   data_type = null,
   category = null,
   classification,
+  label,
   ...otherProps
 }) => {
   const [state, setState] = React.useState(initialMenuState);
@@ -40,7 +49,7 @@ const WrappedActionableCustomChip: React.FC<ActionableCustomChipProps> = ({
     }
   });
 
-  const actionable = isActionable(category, data_type, otherProps.label);
+  const actionable = isActionable(category, data_type, label);
 
   // Do the menu rendering here
   return (
@@ -49,7 +58,7 @@ const WrappedActionableCustomChip: React.FC<ActionableCustomChipProps> = ({
         <ActionMenu
           category={category}
           type={data_type}
-          value={otherProps.label}
+          value={label}
           state={state}
           setState={setState}
           searchTagExternal={searchTagExternal}

--- a/src/components/visual/CustomChip.tsx
+++ b/src/components/visual/CustomChip.tsx
@@ -1,9 +1,14 @@
-import { Tooltip } from '@mui/material';
-import Chip from '@mui/material/Chip';
+import { Chip, ChipProps, Tooltip } from '@mui/material';
 import { darken } from '@mui/material/styles';
 import makeStyles from '@mui/styles/makeStyles';
 import clsx from 'clsx';
-import React, { ReactNode } from 'react';
+import React from 'react';
+
+declare module '@mui/material/Chip' {
+  interface ChipPropsSizeOverrides {
+    tiny: true;
+  }
+}
 
 export const ColorMap = {
   'label-default': 'default' as 'default',
@@ -23,14 +28,10 @@ export const ColorMap = {
 };
 export type PossibleColors = 'default' | 'primary' | 'secondary' | 'info' | 'success' | 'warning' | 'error';
 
-export interface CustomChipProps {
-  className?: string;
-  type?: 'round' | 'square' | 'rounded';
-  size?: 'tiny' | 'small' | 'medium';
-  color?: PossibleColors;
-  variant?: 'filled' | 'outlined';
+export type CustomChipProps = ChipProps & {
+  component?: React.ElementType;
+  fullWidth?: boolean;
   mono?: boolean;
-  wrap?: boolean;
   tooltip?: string;
   tooltipPlacement?:
     | 'bottom-end'
@@ -45,10 +46,9 @@ export interface CustomChipProps {
     | 'top-end'
     | 'top-start'
     | 'top';
-  fullWidth?: boolean;
-  children?: ReactNode;
-  [propName: string]: any;
-}
+  type?: 'round' | 'square' | 'rounded';
+  wrap?: boolean;
+};
 
 const useStyles = makeStyles(theme => ({
   auto_height: {


### PR DESCRIPTION
This fix solves the issue where the ChipList used for the filter query on the Malware Archive, Retrohunt and Error Viewer pages to not work correctly. The issue is that the changes introduced in this patch prevents the onClick event listener to work in the CustomChip component used in the ChipList.

This solution basically creates a new "ActionableChipList" that implements the ActionableCustomChip to be used everywhere else other than the problematic pages. The ChipList is mostly reverted to what it was before with some minor Typescript changes. 