### PR TITLE
Bugfix/Print

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,8 @@
     color: rgba(0, 0, 0, 0.87) !important;
     page-break-after: avoid;
     page-break-before: avoid;
+    -webkit-print-color-adjust: exact; /*chrome & webkit browsers*/
+    print-color-adjust: exact; /*firefox & IE */
   }
 
   #root {


### PR DESCRIPTION
This patch is to solve the ticket [AL-1449](https://cccs.atlassian.net/browse/AL-1449) where printing the submission report would not show the right colors in the Firefox and Edge browsers.

It is solved by adding the "print-color-adjust" and  "-webkit-print-color-adjust" to be exact on the body of the main CSS file.