### PR TITLE
Bugfix/MenuItem Link

### DIFF
--- a/src/components/visual/Attack.tsx
+++ b/src/components/visual/Attack.tsx
@@ -12,7 +12,7 @@ import CustomChip, { PossibleColors } from 'components/visual/CustomChip';
 import { safeFieldValueURI } from 'helpers/utils';
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router';
+import { Link } from 'react-router-dom';
 
 const STYLE = { height: 'auto', minHeight: '20px' };
 const SEARCH_ICON = <SearchOutlinedIcon style={{ marginRight: '16px' }} />;
@@ -44,7 +44,6 @@ const WrappedAttack: React.FC<AttackProps> = ({
 }) => {
   const { t } = useTranslation();
   const [state, setState] = React.useState(initialMenuState);
-  const navigate = useNavigate();
   const { isHighlighted, triggerHighlight } = useHighlighter();
   const { copy } = useClipboard();
   const { showSafeResults } = useSafeResults();
@@ -52,12 +51,6 @@ const WrappedAttack: React.FC<AttackProps> = ({
   const { user: currentUser } = useAppUser<CustomUser>();
 
   const handleClick = useCallback(() => triggerHighlight(highlight_key), [triggerHighlight, highlight_key]);
-
-  const searchAttack = useCallback(
-    () => navigate(`/search/result?query=result.sections.heuristic.attack.pattern:${safeFieldValueURI(text)}`),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [text]
-  );
 
   const maliciousness = lvl || scoreToVerdict(score);
   const color: PossibleColors = {
@@ -85,11 +78,6 @@ const WrappedAttack: React.FC<AttackProps> = ({
     handleClose();
   }, [copy, handleClose, text]);
 
-  const handleMenuSearch = useCallback(() => {
-    searchAttack();
-    handleClose();
-  }, [searchAttack, handleClose]);
-
   const handleMenuHighlight = useCallback(() => {
     handleClick();
     handleClose();
@@ -110,7 +98,12 @@ const WrappedAttack: React.FC<AttackProps> = ({
           {t('clipboard')}
         </MenuItem>
         {currentUser.roles.includes('submission_view') && (
-          <MenuItem dense onClick={handleMenuSearch}>
+          <MenuItem
+            component={Link}
+            dense
+            onClick={handleClose}
+            to={`/search/result?query=result.sections.heuristic.attack.pattern:${safeFieldValueURI(text)}`}
+          >
             {SEARCH_ICON}
             {t('related')}
           </MenuItem>

--- a/src/components/visual/Heuristic.tsx
+++ b/src/components/visual/Heuristic.tsx
@@ -13,7 +13,7 @@ import CustomChip, { PossibleColors } from 'components/visual/CustomChip';
 import { safeFieldValueURI } from 'helpers/utils';
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router';
+import { Link } from 'react-router-dom';
 import InputDialog from './InputDialog';
 
 const STYLE = { height: 'auto', minHeight: '20px' };
@@ -54,7 +54,6 @@ const WrappedHeuristic: React.FC<HeuristicProps> = ({
   const [safelistDialog, setSafelistDialog] = React.useState(false);
   const [safelistReason, setSafelistReason] = React.useState(null);
   const [waitingDialog, setWaitingDialog] = React.useState(false);
-  const navigate = useNavigate();
   const { apiCall } = useMyAPI();
   const { showSuccessMessage } = useMySnackbar();
   const { isHighlighted, triggerHighlight } = useHighlighter();
@@ -63,15 +62,6 @@ const WrappedHeuristic: React.FC<HeuristicProps> = ({
   const { showSafeResults } = useSafeResults();
 
   const handleClick = useCallback(() => triggerHighlight(highlight_key), [triggerHighlight, highlight_key]);
-
-  const searchHeuristic = useCallback(
-    () =>
-      navigate(
-        `/search/result?query=result.sections.heuristic${signature ? '.signature' : ''}.name:${safeFieldValueURI(text)}`
-      ),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [signature, text]
-  );
 
   const handleMenuClick = useCallback(event => {
     event.preventDefault();
@@ -89,11 +79,6 @@ const WrappedHeuristic: React.FC<HeuristicProps> = ({
     copy(text, 'clipID');
     handleClose();
   }, [copy, handleClose, text]);
-
-  const handleMenuSearch = useCallback(() => {
-    searchHeuristic();
-    handleClose();
-  }, [searchHeuristic, handleClose]);
 
   const handleMenuHighlight = useCallback(() => {
     handleClick();
@@ -177,7 +162,14 @@ const WrappedHeuristic: React.FC<HeuristicProps> = ({
           {t('clipboard')}
         </MenuItem>
         {currentUser.roles.includes('submission_view') && (
-          <MenuItem dense onClick={handleMenuSearch}>
+          <MenuItem
+            component={Link}
+            dense
+            onClick={handleClose}
+            to={`/search/result?query=result.sections.heuristic${
+              signature ? '.signature' : ''
+            }.name:${safeFieldValueURI(text)}`}
+          >
             {SEARCH_ICON}
             {t('related')}
           </MenuItem>


### PR DESCRIPTION
This patch is to fix the ticket [AL-2512](https://cccs.atlassian.net/browse/AL-2512). Middle Click to open a link in another tab wasn't available in the Heuristic and Attack section of the Submission page. It was fixed by using a Link component with the "to" property defined as opposed to using navigate().