### PR TITLE
Bugfix/Alerts Link (dev)

### DIFF
--- a/src/components/routes/alerts/alert-events.tsx
+++ b/src/components/routes/alerts/alert-events.tsx
@@ -70,9 +70,9 @@ const WrappedAlertEventsTable = ({ alert, viewHistory, setViewHistory }) => {
                   {alert.events
                     .sort((a, b) => a.ts.localeCompare(b.ts) || b.ts.localeCompare(a.ts))
                     .reverse()
-                    .map(event => {
+                    .map((event, i) => {
                       return (
-                        <TableRow hover tabIndex={-1}>
+                        <TableRow key={`table-row-${i}`} hover tabIndex={-1}>
                           <Tooltip title={event.ts}>
                             <TableCell>
                               <Moment fromNow locale={i18n.language}>


### PR DESCRIPTION
The Alert Detail page that opens in the drawer will now use the location hash to determine if it is open or not. This allows users to share the current URL and have the Alert Detail page to open on the initial load.

However, some of the functionality is lost by doing so since some values are set when the user clicks on an Alert row on the Alerts page. The components that drives those functionality are in our Template-UI's common library, which should not be changed in the event that we update that library to its latest version in the future. Doing so will delete that change.