### PR TITLE
Bugfix/FileViewer (dev)

### DIFF
--- a/src/components/routes/admin/error_detail.tsx
+++ b/src/components/routes/admin/error_detail.tsx
@@ -12,14 +12,15 @@ import PageCenter from 'commons/components/pages/PageCenter';
 import useClipboard from 'commons/components/utils/hooks/useClipboard';
 import useMyAPI from 'components/hooks/useMyAPI';
 import { CustomUser } from 'components/hooks/useMyUser';
+import { DEFAULT_TAB, TAB_OPTIONS } from 'components/routes/file/viewer';
 import FileDownloader from 'components/visual/FileDownloader';
 import 'moment/locale/fr';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { BsClipboard } from 'react-icons/bs';
 import Moment from 'react-moment';
 import { Navigate } from 'react-router';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router-dom';
 
 export type Error = {
   created: string;
@@ -64,6 +65,7 @@ export const ErrorDetail = ({ error_key }: ErrorDetailProps) => {
   const { copy } = useClipboard();
   const [error, setError] = useState<Error>(null);
   const { apiCall } = useMyAPI();
+  const location = useLocation();
   const { key, type, source, name } = useParams<ParamProps>();
   const { user: currentUser } = useAppUser<CustomUser>();
   const downSM = useMediaQuery(theme.breakpoints.down('md'));
@@ -78,6 +80,13 @@ export const ErrorDetail = ({ error_key }: ErrorDetailProps) => {
     'MAX FILES REACHED': <PanToolOutlinedIcon style={{ color: theme.palette.action.active }} />,
     UNKNOWN: <ReportProblemOutlinedIcon style={{ color: theme.palette.action.active }} />
   };
+
+  const fileViewerPath = useMemo<string>(() => {
+    const tab = TAB_OPTIONS.find(option => location.pathname.indexOf(option) >= 0);
+    if (!location.pathname.startsWith('/file/viewer') || !tab)
+      return `/file/viewer/${error?.sha256}/${DEFAULT_TAB}/${location.search}${location.hash}`;
+    else return `/file/viewer/${error?.sha256}/${tab}/${location.search}${location.hash}`;
+  }, [error?.sha256, location.hash, location.pathname, location.search]);
 
   useEffect(() => {
     if ((error_key || key) && currentUser.is_admin) {
@@ -192,7 +201,7 @@ export const ErrorDetail = ({ error_key }: ErrorDetailProps) => {
                   tooltip={t('download')}
                 />
                 <Tooltip title={t('file_viewer')}>
-                  <IconButton component={Link} to={`/file/viewer/${error.sha256}`} size="large">
+                  <IconButton component={Link} to={fileViewerPath} size="large">
                     <PageviewOutlinedIcon />
                   </IconButton>
                 </Tooltip>

--- a/src/components/routes/routes.tsx
+++ b/src/components/routes/routes.tsx
@@ -112,6 +112,7 @@ const WrappedRoutes = () => {
         <Route path="/crash" element={<CrashTest />} />
         <Route path="/dashboard" element={<Dashboard />} />
         <Route path="/file/detail/:id" element={<FileFullDetail />} />
+        <Route path="/file/viewer/:id/:tab" element={<FileViewer />} />
         <Route path="/file/viewer/:id" element={<FileViewer />} />
         <Route path="/help" element={<Help />} />
         <Route path="/help/api" element={<HelpApiDoc />} />

--- a/src/components/visual/FileDetail.tsx
+++ b/src/components/visual/FileDetail.tsx
@@ -26,10 +26,11 @@ import useMyAPI from 'components/hooks/useMyAPI';
 import useMySnackbar from 'components/hooks/useMySnackbar';
 import { CustomUser } from 'components/hooks/useMyUser';
 import ForbiddenPage from 'components/routes/403';
+import { DEFAULT_TAB, TAB_OPTIONS } from 'components/routes/file/viewer';
 import Classification from 'components/visual/Classification';
 import { Error } from 'components/visual/ErrorCard';
 import { AlternateResult, emptyResult, Result } from 'components/visual/ResultCard';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
 import { Link, useLocation } from 'react-router-dom';
@@ -134,6 +135,13 @@ const WrappedFileDetail: React.FC<FileDetailProps> = ({
   const location = useLocation();
   const params = new URLSearchParams(location.search);
   const fileName = file ? params.get('name') || sha256 : null;
+
+  const fileViewerPath = useMemo<string>(() => {
+    const tab = TAB_OPTIONS.find(option => location.pathname.indexOf(option) >= 0);
+    if (!location.pathname.startsWith('/file/viewer') || !tab)
+      return `/file/viewer/${file?.file_info?.sha256}/${DEFAULT_TAB}/${location.search}${location.hash}`;
+    else return `/file/viewer/${file?.file_info?.sha256}/${tab}/${location.search}${location.hash}`;
+  }, [file?.file_info?.sha256, location.hash, location.pathname, location.search]);
 
   const elementInViewport = element => {
     const bounding = element.getBoundingClientRect();
@@ -303,7 +311,7 @@ const WrappedFileDetail: React.FC<FileDetailProps> = ({
                 )}
                 {currentUser.roles.includes('file_detail') && (
                   <Tooltip title={t('file_viewer')}>
-                    <IconButton component={Link} to={`/file/viewer/${file.file_info.sha256}`} size="large">
+                    <IconButton component={Link} to={fileViewerPath} size="large">
                       <PageviewOutlinedIcon />
                     </IconButton>
                   </Tooltip>

--- a/src/components/visual/ResultCard/extracted_file.tsx
+++ b/src/components/visual/ResultCard/extracted_file.tsx
@@ -1,9 +1,10 @@
 import PageviewOutlinedIcon from '@mui/icons-material/PageviewOutlined';
 import { IconButton, Link, Tooltip } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
-import React from 'react';
+import { DEFAULT_TAB, TAB_OPTIONS } from 'components/routes/file/viewer';
+import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink, useLocation } from 'react-router-dom';
 
 export type ExtractedFiles = {
   classification: string;
@@ -48,6 +49,15 @@ const useStyles = makeStyles(theme => ({
 const WrappedExtractedFile: React.FC<ExtractedFileProps> = ({ file, download = false, sid = null }) => {
   const { t } = useTranslation(['fileDetail']);
   const classes = useStyles();
+  const location = useLocation();
+
+  const fileViewerPath = useMemo<string>(() => {
+    const tab = TAB_OPTIONS.find(option => location.pathname.indexOf(option) >= 0);
+    if (!location.pathname.startsWith('/file/viewer') || !tab)
+      return `/file/viewer/${file?.sha256}/${DEFAULT_TAB}/${location.search}${location.hash}`;
+    else return `/file/viewer/${file?.sha256}/${tab}/${location.search}${location.hash}`;
+  }, [file?.sha256, location.hash, location.pathname, location.search]);
+
   return (
     <div className={classes.line}>
       <div className={classes.text}>
@@ -75,7 +85,7 @@ const WrappedExtractedFile: React.FC<ExtractedFileProps> = ({ file, download = f
       </div>
       <div className={classes.button}>
         <Tooltip title={`${t('view_file')}: ${file.name}`} placement="left">
-          <IconButton component={RouterLink} to={`/file/viewer/${file.sha256}`} size="small" color="primary">
+          <IconButton component={RouterLink} to={fileViewerPath} size="small" color="primary">
             <PageviewOutlinedIcon />
           </IconButton>
         </Tooltip>


### PR DESCRIPTION
This is a patch for the ticket [AL-2535](https://cccs.atlassian.net/browse/AL-2535).

As stated in the ticket, the tab detection treated "ascii" and "" the same. So, when you glitched the system into going on the HexViewer without a hash, selecting the "ascii" tab would not work because the system's state was already on it.

I changed the FileViewer's tab parameter from a hash to pathname param because the hash should only be used by the drawer.

To fix the bug, I prevent any null or undefined values by redirecting to the default value if it occurs. That way, tab always has a value.

Also, I changed all the pages that were redirecting to the FileViewer ("ErrorDetail", "FileDetail" and "ExtractedFile") by keeping the tab value if there is one. That way, if a user checkout out the HexViewer of a file and switches to another file, the FileViewer page will stay on the HexViewer.