### PR TITLE
Bugfix/Setting Reset (master)

### DIFF
--- a/src/components/layout/serviceSpec.tsx
+++ b/src/components/layout/serviceSpec.tsx
@@ -12,7 +12,7 @@ import {
 } from '@mui/material';
 import FormControl from '@mui/material/FormControl';
 import makeStyles from '@mui/styles/makeStyles';
-import { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 const useStyles = makeStyles(theme => ({
@@ -28,7 +28,39 @@ const useStyles = makeStyles(theme => ({
   }
 }));
 
-function Service({ disabled, service, idx, setParam, setParamAsync }) {
+type ResetButtonProps = {
+  value: any;
+  defaultValue: any;
+  hasResetButton?: boolean;
+  reset?: () => void;
+};
+
+const WrappedResetButton = ({ value, defaultValue, hasResetButton = false, reset }: ResetButtonProps) => {
+  const { t } = useTranslation(['adminServices']);
+  const theme = useTheme();
+
+  return hasResetButton && value !== defaultValue ? (
+    <Tooltip title={t('reset.tooltip')} placement="right">
+      <Button
+        style={{ marginLeft: theme.spacing(1), padding: 0, lineHeight: '1rem' }}
+        onClick={event => {
+          event.stopPropagation();
+          event.preventDefault();
+          reset();
+        }}
+        size="small"
+        color="secondary"
+        variant="outlined"
+      >
+        {t('reset')}
+      </Button>
+    </Tooltip>
+  ) : null;
+};
+
+const ResetButton = React.memo(WrappedResetButton);
+
+function Service({ disabled, service, idx, hasResetButton = false, setParam, setParamAsync }) {
   const theme = useTheme();
   const [showMore, setShowMore] = useState(false);
   const { t } = useTranslation();
@@ -46,6 +78,7 @@ function Service({ disabled, service, idx, setParam, setParamAsync }) {
               param={param}
               pidx={pidx}
               idx={idx}
+              hasResetButton={hasResetButton}
               setParam={setParam}
               setParamAsync={setParamAsync}
             />
@@ -61,6 +94,7 @@ function Service({ disabled, service, idx, setParam, setParamAsync }) {
                   param={param}
                   pidx={pidx}
                   idx={idx}
+                  hasResetButton={hasResetButton}
                   setParam={setParam}
                   setParamAsync={setParamAsync}
                 />
@@ -77,12 +111,22 @@ function Service({ disabled, service, idx, setParam, setParamAsync }) {
   );
 }
 
-function Param({ disabled, param, pidx, idx, setParam, setParamAsync }) {
+function Param({ disabled, param, pidx, idx, hasResetButton = false, setParam, setParamAsync }) {
   const classes = useStyles();
   const theme = useTheme();
 
   const [value, setValue] = useState<number>(param.value);
   const parsedValue = useMemo<string>(() => `${value}`, [value]);
+
+  const handleIntChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      let num = parseInt(event.target.value);
+      num = isNaN(num) ? 0 : num;
+      setValue(num);
+      setParamAsync(idx, pidx, num);
+    },
+    [idx, pidx, setParamAsync]
+  );
 
   return (
     <div key={pidx} style={{ paddingBottom: theme.spacing(1) }}>
@@ -101,6 +145,12 @@ function Param({ disabled, param, pidx, idx, setParam, setParamAsync }) {
             label={
               <Typography variant="body2" style={{ textTransform: 'capitalize' }}>
                 {param.name.replace(/_/g, ' ')}
+                <ResetButton
+                  value={param.value}
+                  defaultValue={param.default}
+                  hasResetButton={hasResetButton}
+                  reset={() => setParam(idx, pidx, param.default)}
+                />
               </Typography>
             }
             className={!disabled ? classes.item : null}
@@ -111,6 +161,15 @@ function Param({ disabled, param, pidx, idx, setParam, setParamAsync }) {
           <div>
             <Typography variant="caption" gutterBottom style={{ textTransform: 'capitalize' }}>
               {param.name.replace(/_/g, ' ')}
+              <ResetButton
+                value={param.value}
+                defaultValue={param.default}
+                hasResetButton={hasResetButton}
+                reset={() => {
+                  setValue(param.default);
+                  setParam(idx, pidx, param.default);
+                }}
+              />
             </Typography>
           </div>
           {param.type === 'list' ? (
@@ -140,7 +199,7 @@ function Param({ disabled, param, pidx, idx, setParam, setParamAsync }) {
               type="text"
               size="small"
               fullWidth
-              defaultValue={param.value}
+              value={param.value}
               onChange={event => setParamAsync(idx, pidx, event.target.value)}
             />
           ) : (
@@ -151,12 +210,7 @@ function Param({ disabled, param, pidx, idx, setParam, setParamAsync }) {
               size="small"
               fullWidth
               value={parsedValue}
-              onChange={event => {
-                let num = parseInt(event.target.value);
-                num = isNaN(num) ? 0 : num;
-                setValue(num);
-                setParamAsync(idx, pidx, num);
-              }}
+              onChange={handleIntChange}
             />
           )}
         </>
@@ -172,9 +226,18 @@ type ServiceSpecProps = {
   isSelected?: (name: string) => boolean;
   disabled?: boolean;
   compressed?: boolean;
+  hasResetButton?: boolean;
 };
 
-function ServiceSpec({ service_spec, setParam, setParamAsync, isSelected, disabled, compressed }: ServiceSpecProps) {
+function ServiceSpec({
+  service_spec,
+  setParam,
+  setParamAsync,
+  isSelected,
+  disabled,
+  compressed,
+  hasResetButton = false
+}: ServiceSpecProps) {
   const theme = useTheme();
   return (
     <div
@@ -200,6 +263,7 @@ function ServiceSpec({ service_spec, setParam, setParamAsync, isSelected, disabl
               disabled={disabled}
               service={service}
               idx={idx}
+              hasResetButton={hasResetButton}
               setParam={setParam}
               setParamAsync={setParamAsync}
             />

--- a/src/components/layout/serviceSpec.tsx
+++ b/src/components/layout/serviceSpec.tsx
@@ -12,7 +12,7 @@ import {
 } from '@mui/material';
 import FormControl from '@mui/material/FormControl';
 import makeStyles from '@mui/styles/makeStyles';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 const useStyles = makeStyles(theme => ({
@@ -80,6 +80,10 @@ function Service({ disabled, service, idx, setParam, setParamAsync }) {
 function Param({ disabled, param, pidx, idx, setParam, setParamAsync }) {
   const classes = useStyles();
   const theme = useTheme();
+
+  const [value, setValue] = useState<number>(param.value);
+  const parsedValue = useMemo<string>(() => `${value}`, [value]);
+
   return (
     <div key={pidx} style={{ paddingBottom: theme.spacing(1) }}>
       {param.type === 'bool' ? (
@@ -129,15 +133,30 @@ function Param({ disabled, param, pidx, idx, setParam, setParamAsync }) {
                 )}
               </Select>
             </FormControl>
-          ) : (
+          ) : param.type === 'str' ? (
             <TextField
               variant="outlined"
               disabled={disabled}
-              type={param.type === 'int' ? 'number' : 'text'}
+              type="text"
               size="small"
               fullWidth
               defaultValue={param.value}
               onChange={event => setParamAsync(idx, pidx, event.target.value)}
+            />
+          ) : (
+            <TextField
+              variant="outlined"
+              disabled={disabled}
+              type="number"
+              size="small"
+              fullWidth
+              value={parsedValue}
+              onChange={event => {
+                let num = parseInt(event.target.value);
+                num = isNaN(num) ? 0 : num;
+                setValue(num);
+                setParamAsync(idx, pidx, num);
+              }}
             />
           )}
         </>

--- a/src/components/routes/settings.tsx
+++ b/src/components/routes/settings.tsx
@@ -695,6 +695,7 @@ function Settings() {
               setParam={setParam}
               setParamAsync={setParam}
               compressed
+              hasResetButton
             />
           ) : (
             <div>


### PR DESCRIPTION
Added a reset button on all "Service Parameters Value" property in the user's setting page to reset the value to its default one. Also, there was a bug where an "int" parameter value was a string and not a number. This was fixed by modifying the input to handle numbers correctly and ensure no NaN value (showing a 0 instead).