### PR TITLE
Bugfix/Fullscreen (Firefox can't have nice things)

### DIFF
--- a/src/commons/components/pages/PageFullScreen.tsx
+++ b/src/commons/components/pages/PageFullScreen.tsx
@@ -5,7 +5,7 @@ import useAppBar from 'commons/components/app/hooks/useAppBar';
 import useAppBarHeight from 'commons/components/app/hooks/useAppBarHeight';
 import useAppLayout from 'commons/components/app/hooks/useAppLayout';
 import useFullscreenStatus from 'commons/components/utils/hooks/useFullscreenStatus';
-import { memo, useCallback, useRef } from 'react';
+import { memo, useCallback, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import PageContent from './PageContent';
 
@@ -30,6 +30,8 @@ const PageFullscreen = ({ children, margin = null, mb = 2, ml = 2, mr = 2, mt = 
   let fullscreenSupported: boolean;
 
   const barWillHide = layout.current !== 'top' && appbar.autoHide;
+
+  const isFirefox = useMemo(() => /Firefox|firefox/.test(navigator.userAgent.toString()), []);
 
   try {
     [isFullscreen, setIsFullscreen] = useFullscreenStatus(maximizableElement);
@@ -60,9 +62,17 @@ const PageFullscreen = ({ children, margin = null, mb = 2, ml = 2, mr = 2, mt = 
           top: barWillHide || isFullscreen ? 0 : appBarHeight,
           float: 'right',
           paddingTop: theme.spacing(2),
-          position: 'fixed',
           right: theme.spacing(2),
-          zIndex: theme.zIndex.appBar + 1
+          zIndex: theme.zIndex.appBar + 1,
+          ...(isFirefox
+            ? {
+                position: 'fixed',
+                top: isFullscreen ? 0 : appBarHeight
+              }
+            : {
+                position: 'sticky',
+                top: barWillHide || isFullscreen ? 0 : appBarHeight
+              })
         }}
       >
         {fullscreenSupported ? null : (

--- a/src/commons/components/pages/PageFullScreen.tsx
+++ b/src/commons/components/pages/PageFullScreen.tsx
@@ -1,6 +1,6 @@
 import FullscreenIcon from '@mui/icons-material/Fullscreen';
 import FullscreenExitIcon from '@mui/icons-material/FullscreenExit';
-import { Box, IconButton, Tooltip } from '@mui/material';
+import { IconButton, Tooltip, useTheme } from '@mui/material';
 import useAppBar from 'commons/components/app/hooks/useAppBar';
 import useAppBarHeight from 'commons/components/app/hooks/useAppBarHeight';
 import useAppLayout from 'commons/components/app/hooks/useAppLayout';
@@ -24,6 +24,7 @@ const PageFullscreen = ({ children, margin = null, mb = 2, ml = 2, mr = 2, mt = 
   const layout = useAppLayout();
   const appbar = useAppBar();
   const { t } = useTranslation();
+  const theme = useTheme();
   let isFullscreen: boolean;
   let setIsFullscreen: () => void;
   let fullscreenSupported: boolean;
@@ -47,34 +48,37 @@ const PageFullscreen = ({ children, margin = null, mb = 2, ml = 2, mr = 2, mt = 
   };
 
   return (
-    <Box
+    <div
       ref={maximizableElement}
-      component="div"
-      sx={theme => ({ backgroundColor: theme.palette.background.default, overflowY: isFullscreen ? 'auto' : 'unset' })}
+      style={{
+        backgroundColor: theme.palette.background.default,
+        overflowY: isFullscreen ? 'auto' : 'unset'
+      }}
     >
-      <Box
-        component="div"
-        sx={theme => ({
+      <div
+        style={{
           top: barWillHide || isFullscreen ? 0 : appBarHeight,
           float: 'right',
           paddingTop: theme.spacing(2),
-          position: 'sticky',
+          position: 'fixed',
           right: theme.spacing(2),
           zIndex: theme.zIndex.appBar + 1
-        })}
+        }}
       >
         {fullscreenSupported ? null : (
           <Tooltip title={t(isFullscreen ? 'fullscreen.off' : 'fullscreen.on')}>
-            <IconButton onClick={isFullscreen ? handleExitFullscreen : handleEnterFullscreen} size="large">
-              {isFullscreen ? <FullscreenExitIcon /> : <FullscreenIcon />}
-            </IconButton>
+            <div>
+              <IconButton onClick={isFullscreen ? handleExitFullscreen : handleEnterFullscreen} size="large">
+                {isFullscreen ? <FullscreenExitIcon /> : <FullscreenIcon />}
+              </IconButton>
+            </div>
           </Tooltip>
         )}
-      </Box>
+      </div>
       <PageContent margin={margin} mb={mb} ml={ml} mr={mr} mt={mt}>
         {children}
       </PageContent>
-    </Box>
+    </div>
   );
 };
 


### PR DESCRIPTION
On Firefox, there's a bug on the Dashboard page where the page sizing gets miscalculated when receiving data from the socket connection. This is causes by the Fullscreen button having a position sticky style as it is not a well supported feature in Firefox which might cause issues like here.

<img width="983" alt="image" src="https://github.com/CybercentreCanada/assemblyline-ui-frontend/assets/90928403/dfdbe4ad-6739-4871-8602-7fe9bafb404d">

Since the `PageFullscreen` component is only ever used in the Dashboard and only has that button, I detect if the user-agent has "Firefox" and, if it does, I set the position to "fixed". Otherwise, nothing changes.

I also changed the `Box` components for `div` since that's what they were used for.

