### PR TITLE
Support all available hash types when adding files to Badlist

### DIFF
--- a/src/components/routes/manage/badlist_add.tsx
+++ b/src/components/routes/manage/badlist_add.tsx
@@ -203,7 +203,7 @@ const BadlistNew = ({}: Props) => {
     //File specific checks
     else if (badlist?.type === 'file') {
       // There is not at least one hash
-      if (!badlist?.hashes?.md5 && !badlist?.hashes?.sha1 && !badlist?.hashes?.sha256) {
+      if (!badlist?.hashes) {
         setReady(false);
         return;
       }

--- a/src/locales/en/manage/badlist_add.json
+++ b/src/locales/en/manage/badlist_add.json
@@ -11,7 +11,7 @@
   "details": "Item Details",
   "expiry.title": "Expiry date",
   "file": "File",
-  "file.hashes": "File Hashes (One of MD5, SHA1 or SHA256 is required) *",
+  "file.hashes": "File Hashes (One of the following hashes is required) *",
   "file.prop": "File Properties (Optional)",
   "file.name": "Name",
   "file.size": "Size",

--- a/src/locales/fr/manage/badlist_add.json
+++ b/src/locales/fr/manage/badlist_add.json
@@ -11,7 +11,7 @@
   "details": "Détails de l'élément",
   "expiry.title": "Date d'expiration",
   "file": "Fichier",
-  "file.hashes": "Hachages de fichiers (Au moins un des MD5, SHA1 ou SHA256 est requis) *",
+  "file.hashes": "Hachages de fichiers (Au moins un des hachages suivants est requis) *",
   "file.prop": "Propriétés du fichier (facultatif)",
   "file.name": "Nom",
   "file.size": "Taille",


### PR DESCRIPTION
Related to: https://github.com/CybercentreCanada/assemblyline/issues/259
Depends on: https://github.com/CybercentreCanada/assemblyline-core/pull/1012

Summary: This (along with the patch to the Badlist client) will allow users also submit TLSH and SSDEEP hashes to be used as the `qhash` when adding items to the Badlist (not solely relying on the presence of SHA256, SHA1, MD5 hashes on addition).