### PR TITLE
Hotfix/Alerts (dev)

### DIFF
--- a/src/components/routes/alerts.tsx
+++ b/src/components/routes/alerts.tsx
@@ -80,7 +80,7 @@ const WrappedAlertsContent = () => {
   const [alerts, setAlerts] = useState<Alert[]>([]);
   const [countedTotal, setCountedTotal] = useState<number>(0);
   const [total, setTotal] = useState<number>(0);
-  const [loading, setLoading] = useState<boolean>(false);
+  const [loading, setLoading] = useState<boolean>(true);
   const [scrollReset, setScrollReset] = useState<boolean>(false);
 
   const prevSearch = useRef<string>(null);


### PR DESCRIPTION
Set loading to true at first to avoid having the "no result" card on initial navigate.