### PR TITLE
Bugfix/WorkflowDetail (dev)

### DIFF
--- a/src/components/routes/manage/workflows/create.tsx
+++ b/src/components/routes/manage/workflows/create.tsx
@@ -214,7 +214,7 @@ const WrappedWorkflowCreate = ({ id: propID = null, search = null, onClose = () 
       if (!!workflow?.query && currentUser.roles.includes('alert_view')) {
         apiCall<SearchResult<Alert>>({
           method: 'GET',
-          url: `/api/v4/search/alert/?query=${encodeURI(workflow?.query)}&rows=10&track_total_hits=true`,
+          url: `/api/v4/search/alert/?query=${encodeURIComponent(workflow?.query)}&rows=10&track_total_hits=true`,
           onSuccess: ({ api_response }) => {
             setResults(api_response);
             setBadQuery(false);


### PR DESCRIPTION
Fixed a bug where queries that use # returned an error. Using encodeURIComponent()