### PR TITLE
Bugfix/FileViewer (master)

### DIFF
--- a/src/components/routes/file/viewer.tsx
+++ b/src/components/routes/file/viewer.tsx
@@ -157,7 +157,6 @@ const WrappedFileViewer: React.FC<Props> = () => {
             value={paramTab}
             defaultTab={DEFAULT_TAB}
             paper
-            selectionFollowsFocus
             onChange={(_event, value) =>
               navigate(`/file/viewer/${sha256}/${value}/${location.search}${location.hash}`, { replace: true })
             }

--- a/src/components/visual/TabContainer.tsx
+++ b/src/components/visual/TabContainer.tsx
@@ -129,7 +129,7 @@ const WrappedTabContainer = <T extends TabElements>({
         >
           {Object.entries(tabs).map(([value, { label = '', disabled = false }], i) =>
             disabled ? null : (
-              <Tab key={i} tabIndex={-1} role={null} label={label} value={value} sx={{ minWidth: '120px' }} />
+              <Tab key={i} tabIndex={0} role="button" label={label} value={value} sx={{ minWidth: '120px' }} />
             )
           )}
         </Tabs>

--- a/src/components/visual/TabContainer.tsx
+++ b/src/components/visual/TabContainer.tsx
@@ -3,20 +3,6 @@ import { Tab, Tabs, useTheme } from '@mui/material';
 import type { FC, ReactElement, ReactNode } from 'react';
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
-interface TabElement extends TabProps {
-  inner?: ReactNode;
-}
-
-type TabElements = Record<string, TabElement>;
-
-interface Props<T extends TabElements> extends TabsProps {
-  defaultTab?: keyof T;
-  paper?: boolean;
-  value?: keyof T;
-  tabs: T;
-  stickyTop?: null | number;
-}
-
 type TabContextProps = {
   onTabChange: (value: string) => void;
 };
@@ -29,6 +15,40 @@ const TabContext = React.createContext<TabContextProps>(null);
 
 export function useTab(): TabContextProps {
   return useContext(TabContext);
+}
+
+interface TabContentProps extends React.HTMLProps<HTMLDivElement> {
+  children?: React.ReactNode;
+  open?: boolean;
+}
+
+const WrappedTabContent: FC<TabContentProps> = ({ children, name = '', style, open = false, ...other }) => {
+  const [render, setRender] = useState<boolean>(open);
+  useEffect(() => {
+    if (open === true) setRender(true);
+  }, [open]);
+
+  return (
+    <div {...other} style={{ display: open ? 'contents' : 'none', ...style }}>
+      {render && children}
+    </div>
+  );
+};
+
+export const TabContent = React.memo(WrappedTabContent);
+
+interface TabElement extends TabProps {
+  inner?: ReactNode;
+}
+
+type TabElements = Record<string, TabElement>;
+
+interface Props<T extends TabElements> extends TabsProps {
+  defaultTab?: keyof T;
+  paper?: boolean;
+  value?: keyof T;
+  tabs: T;
+  stickyTop?: null | number;
 }
 
 const WrappedTabContainer = <T extends TabElements>({
@@ -109,16 +129,7 @@ const WrappedTabContainer = <T extends TabElements>({
         >
           {Object.entries(tabs).map(([value, { label = '', disabled = false }], i) =>
             disabled ? null : (
-              <Tab
-                key={i}
-                tabIndex={0}
-                label={label}
-                value={value}
-                sx={{ minWidth: '120px' }}
-                onClick={(event: any) => {
-                  event?.target?.blur();
-                }}
-              />
+              <Tab key={i} tabIndex={-1} role={null} label={label} value={value} sx={{ minWidth: '120px' }} />
             )
           )}
         </Tabs>
@@ -132,22 +143,3 @@ const WrappedTabContainer = <T extends TabElements>({
 };
 
 export const TabContainer = React.memo(WrappedTabContainer);
-
-interface TabContentProps extends React.HTMLProps<HTMLDivElement> {
-  children?: React.ReactNode;
-  open?: boolean;
-}
-
-const WrappedTabContent: FC<TabContentProps> = ({ children, name = '', style, open = false, ...other }) => {
-  const [render, setRender] = useState<boolean>(open);
-  useEffect(() => {
-    if (open === true) setRender(true);
-  }, [open]);
-  return (
-    <div {...other} style={{ display: open ? 'contents' : 'none', ...style }}>
-      {render && children}
-    </div>
-  );
-};
-
-export const TabContent = React.memo(WrappedTabContent);

--- a/src/components/visual/TabContainer.tsx
+++ b/src/components/visual/TabContainer.tsx
@@ -1,5 +1,7 @@
-import { Tab, TabProps, Tabs, TabsProps, useTheme } from '@mui/material';
-import React, { FC, ReactElement, ReactNode, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import type { TabProps, TabsProps } from '@mui/material';
+import { Tab, Tabs, useTheme } from '@mui/material';
+import type { FC, ReactElement, ReactNode } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
 interface TabElement extends TabProps {
   inner?: ReactNode;
@@ -26,7 +28,7 @@ export interface TabProviderProps {
 const TabContext = React.createContext<TabContextProps>(null);
 
 export function useTab(): TabContextProps {
-  return useContext(TabContext) as TabContextProps;
+  return useContext(TabContext);
 }
 
 const WrappedTabContainer = <T extends TabElements>({
@@ -106,7 +108,18 @@ const WrappedTabContainer = <T extends TabElements>({
           {...props}
         >
           {Object.entries(tabs).map(([value, { label = '', disabled = false }], i) =>
-            disabled ? null : <Tab key={i} label={label} value={value} sx={{ minWidth: '120px' }} />
+            disabled ? null : (
+              <Tab
+                key={i}
+                tabIndex={0}
+                label={label}
+                value={value}
+                sx={{ minWidth: '120px' }}
+                onClick={(event: any) => {
+                  event?.target?.blur();
+                }}
+              />
+            )
           )}
         </Tabs>
       </div>


### PR DESCRIPTION
This patch is to solve the focus issue on the FileViewer. Keyboard navigating users are unable to do alt-arrow to go back a page because the focus gets set to the Tab container's buttons that listens to the arrow keys.

My fix is to add an onClick event listener on each tab button to blur the focus from themselves.

(note: I need to ensure the blur also works on enter key also)

(note: This might cause an accessibility issue since the focus doesn't remain on the Tab Container preventing users without a mouse to efficiently navigate between tabs... )