### PR TITLE
Bugfix/ServiceDetail (master)

### DIFF
--- a/src/components/routes/admin/services.tsx
+++ b/src/components/routes/admin/services.tsx
@@ -239,14 +239,7 @@ export default function Services() {
 
   useEffect(() => {
     if (location.hash) {
-      setGlobalDrawer(
-        <ServiceDetail
-          name={location.hash.slice(1)}
-          serviceNames={serviceNames}
-          onDeleted={onDeleted}
-          onUpdated={onUpdated}
-        />
-      );
+      setGlobalDrawer(<ServiceDetail name={location.hash.slice(1)} onDeleted={onDeleted} onUpdated={onUpdated} />);
     } else {
       closeGlobalDrawer();
     }

--- a/src/helpers/utils.test.ts
+++ b/src/helpers/utils.test.ts
@@ -346,7 +346,7 @@ describe('Test `getValueFromPath`', () => {
 describe('Test `getProvider`', () => {
   const loc = { ...window.location };
   afterEach(() => {
-    window.location = loc as Location;
+    window.location = loc as unknown as Location & string;
   });
 
   it('Should return correct provider info if pathname provides oauth', () => {
@@ -393,7 +393,7 @@ describe('Test `getProvider`', () => {
 describe('Test `searchResultsDisplay`', () => {
   const loc = { ...window.location };
   afterEach(() => {
-    window.location = loc as Location;
+    window.location = loc as unknown as Location & string;
   });
 
   it('Should return the exact count if not at the ES limit', () => {

--- a/src/helpers/utils.test.ts
+++ b/src/helpers/utils.test.ts
@@ -344,7 +344,7 @@ describe('Test `getValueFromPath`', () => {
 });
 
 describe('Test `getProvider`', () => {
-  let loc = { ...window.location };
+  const loc = { ...window.location };
   afterEach(() => {
     window.location = loc;
   });
@@ -391,7 +391,7 @@ describe('Test `getProvider`', () => {
 });
 
 describe('Test `searchResultsDisplay`', () => {
-  let loc = { ...window.location };
+  const loc = { ...window.location };
   afterEach(() => {
     window.location = loc;
   });

--- a/src/helpers/utils.test.ts
+++ b/src/helpers/utils.test.ts
@@ -346,7 +346,7 @@ describe('Test `getValueFromPath`', () => {
 describe('Test `getProvider`', () => {
   const loc = { ...window.location };
   afterEach(() => {
-    window.location = loc;
+    window.location = loc as Location;
   });
 
   it('Should return correct provider info if pathname provides oauth', () => {
@@ -393,7 +393,7 @@ describe('Test `getProvider`', () => {
 describe('Test `searchResultsDisplay`', () => {
   const loc = { ...window.location };
   afterEach(() => {
-    window.location = loc;
+    window.location = loc as Location;
   });
 
   it('Should return the exact count if not at the ES limit', () => {


### PR DESCRIPTION
Fixed a bug where opening the `ServiceDetail` page in a new tab was stuck loading because all the service names weren't being propagated by the `Services` page.