### PR TITLE
Confirm nav on upload

### DIFF
--- a/src/components/routes/submit.tsx
+++ b/src/components/routes/submit.tsx
@@ -140,12 +140,21 @@ const Submit = () => {
     flow.off('fileError');
     flow.off('progress');
     setUUID(generateUUID());
+    warnOnReload(false);
+  };
+
+  // If true, will show a "Reload Site?" warning when the user tries to navigate away from the page
+  // If false, will not show the warning
+  const warnOnReload = (warn: boolean) => {
+    window.onbeforeunload = warn ? () => true : null;
   };
 
   const uploadAndScan = () => {
     flow.opts.generateUniqueIdentifier = getFileUUID;
     setAllowClick(false);
     setUploadProgress(0);
+    warnOnReload(true);
+
     flow.on('fileError', (event, api_data) => {
       try {
         const data = JSON.parse(api_data);
@@ -173,6 +182,8 @@ const Submit = () => {
       setUploadProgress(Math.trunc(flow.progress() * 100));
     });
     flow.on('complete', () => {
+      warnOnReload(false);
+
       if (flow.files.length === 0) {
         return;
       }

--- a/src/components/routes/submit.tsx
+++ b/src/components/routes/submit.tsx
@@ -140,12 +140,12 @@ const Submit = () => {
     flow.off('fileError');
     flow.off('progress');
     setUUID(generateUUID());
-    warnOnReload(false);
+    warnOnUnload(false);
   };
 
   // If true, will show a "Reload Site?" warning when the user tries to navigate away from the page
   // If false, will not show the warning
-  const warnOnReload = (warn: boolean) => {
+  const warnOnUnload = (warn: boolean) => {
     window.onbeforeunload = warn ? () => true : null;
   };
 
@@ -153,7 +153,7 @@ const Submit = () => {
     flow.opts.generateUniqueIdentifier = getFileUUID;
     setAllowClick(false);
     setUploadProgress(0);
-    warnOnReload(true);
+    warnOnUnload(true);
 
     flow.on('fileError', (event, api_data) => {
       try {
@@ -182,7 +182,7 @@ const Submit = () => {
       setUploadProgress(Math.trunc(flow.progress() * 100));
     });
     flow.on('complete', () => {
-      warnOnReload(false);
+      warnOnUnload(false);
 
       if (flow.files.length === 0) {
         return;


### PR DESCRIPTION
## Description
Adds a browser-level confirmation dialog when navigating away from the submit page while a file is being uploaded to prevent accidental navigation.

## Changes
- Implemented `warnOnUnload` method to enable browser's default "Leave site?" confirmation dialog when there are pending changes
- Uses `window.onbeforeunload` event to trigger navigation warning
- This handler is set when file upload starts, and unset when upload is cancelled or completed.

![image](https://github.com/user-attachments/assets/a893b805-f50a-4880-afbd-d6ea68dc0d87)

