### PR TITLE
Bugfix/SearchKeys (master)

### DIFF
--- a/src/components/routes/retrohunt/detail.tsx
+++ b/src/components/routes/retrohunt/detail.tsx
@@ -763,7 +763,7 @@ function WrappedRetrohuntDetailPage({ search_key: propKey = null, isDrawer = fal
                                 <DivTableBody id="hit-body">
                                   {hitResults.items.map((file, i) => (
                                     <LinkRow
-                                      key={i}
+                                      key={`${file.sha256}-${i}`}
                                       component={Link}
                                       to={`/file/detail/${file.sha256}`}
                                       hover

--- a/src/components/routes/retrohunt/errors.tsx
+++ b/src/components/routes/retrohunt/errors.tsx
@@ -184,7 +184,7 @@ const WrappedRetrohuntErrors = ({ retrohunt = null, isDrawer = false }: Props) =
                 </DivTableHead>
                 <DivTableBody>
                   {errorResults.items.map((error, id) => (
-                    <DivTableRow key={id} hover style={{ textDecoration: 'none' }}>
+                    <DivTableRow key={`${error.type}-${id}`} hover style={{ textDecoration: 'none' }}>
                       {error.type === 'warning' ? (
                         <DivTableCell style={{ paddingLeft: theme.spacing(2) }}>
                           <WarningAmberOutlinedIcon color="warning" />

--- a/src/components/visual/SearchResult/alerts.tsx
+++ b/src/components/visual/SearchResult/alerts.tsx
@@ -59,9 +59,9 @@ const WrappedAlertsTable: React.FC<Props> = ({ alertResults, allowSort = true })
             </DivTableRow>
           </DivTableHead>
           <DivTableBody>
-            {alertResults.items.map(alert => (
+            {alertResults.items.map((alert, i) => (
               <LinkRow
-                key={alert.id}
+                key={`${alert.id}-${i}`}
                 component={Link}
                 to={`/alerts/${alert.id}`}
                 hover

--- a/src/components/visual/SearchResult/apikeys.tsx
+++ b/src/components/visual/SearchResult/apikeys.tsx
@@ -88,9 +88,9 @@ const WrappedUsersApiTable: React.FC<ApiTableProps> = ({ apikeySearchResults, se
         </DivTableHead>
 
         <DivTableBody>
-          {apikeySearchResults.items.map(userApikey => (
+          {apikeySearchResults.items.map((userApikey, i) => (
             <LinkRow
-              key={userApikey.id}
+              key={`${userApikey.id}-${i}`}
               hover
               component={Link}
               to={`/admin/apikeys/${userApikey.id}`}

--- a/src/components/visual/SearchResult/badlist.tsx
+++ b/src/components/visual/SearchResult/badlist.tsx
@@ -70,9 +70,9 @@ const WrappedBadlistTable: React.FC<Props> = ({ badlistResults, allowSort = true
           </DivTableRow>
         </DivTableHead>
         <DivTableBody>
-          {badlistResults.items.map(sl_item => (
+          {badlistResults.items.map((sl_item, i) => (
             <LinkRow
-              key={sl_item.id}
+              key={`${sl_item.id}-${i}`}
               component={Link}
               hover
               to={`/manage/badlist/${sl_item.id}`}

--- a/src/components/visual/SearchResult/errors.tsx
+++ b/src/components/visual/SearchResult/errors.tsx
@@ -65,9 +65,9 @@ const WrappedErrorsTable: React.FC<Props> = ({ errorResults, setErrorKey = null,
             </DivTableRow>
           </DivTableHead>
           <DivTableBody>
-            {errorResults.items.map(error => (
+            {errorResults.items.map((error, i) => (
               <LinkRow
-                key={error.id}
+                key={`${error.id}-${i}`}
                 component={Link}
                 to={`/admin/errors/${error.id}`}
                 onClick={event => {

--- a/src/components/visual/SearchResult/files.tsx
+++ b/src/components/visual/SearchResult/files.tsx
@@ -62,7 +62,7 @@ const WrappedFilesTable: React.FC<Props> = ({ fileResults, allowSort = true }) =
           <DivTableBody>
             {fileResults.items.map((file, id) => (
               <LinkRow
-                key={id}
+                key={`${file.id}-${id}`}
                 component={Link}
                 to={`/file/detail/${file.sha256}`}
                 hover

--- a/src/components/visual/SearchResult/heuristics.tsx
+++ b/src/components/visual/SearchResult/heuristics.tsx
@@ -62,9 +62,9 @@ const WrappedHeuristicsTable: React.FC<Props> = ({ heuristicResults, setHeuristi
             </DivTableRow>
           </DivTableHead>
           <DivTableBody>
-            {heuristicResults.items.map(heuristic => (
+            {heuristicResults.items.map((heuristic, i) => (
               <LinkRow
-                key={heuristic.heur_id}
+                key={`${heuristic.heur_id}-${i}`}
                 component={Link}
                 to={`/manage/heuristic/${heuristic.heur_id}`}
                 onClick={event => {

--- a/src/components/visual/SearchResult/results.tsx
+++ b/src/components/visual/SearchResult/results.tsx
@@ -67,7 +67,7 @@ const WrappedResultsTable: React.FC<Props> = ({ resultResults, component = Paper
           <DivTableBody>
             {resultResults.items.map((result, id) => (
               <LinkRow
-                key={id}
+                key={`${result.id}-${id}`}
                 component={Link}
                 to={`/file/detail/${result.id.substring(0, 64)}${location.hash}`}
                 hover

--- a/src/components/visual/SearchResult/retrohunt.tsx
+++ b/src/components/visual/SearchResult/retrohunt.tsx
@@ -116,7 +116,7 @@ const WrappedRetrohuntTable: React.FC<Props> = ({
           <DivTableBody>
             {retrohuntResults.items.map((retrohunt, id) => (
               <LinkRow
-                key={id}
+                key={`${retrohunt.id}-${id}`}
                 component={Link}
                 to={`/retrohunt/${retrohunt.key}`}
                 onClick={event => {

--- a/src/components/visual/SearchResult/safelist.tsx
+++ b/src/components/visual/SearchResult/safelist.tsx
@@ -59,9 +59,9 @@ const WrappedSafelistTable: React.FC<Props> = ({ safelistResults, setSafelistID 
             </DivTableRow>
           </DivTableHead>
           <DivTableBody>
-            {safelistResults.items.map(sl_item => (
+            {safelistResults.items.map((sl_item, i) => (
               <LinkRow
-                key={sl_item.id}
+                key={`${sl_item.id}-${i}`}
                 component={Link}
                 to={`/manage/safelist/${sl_item.id}`}
                 onClick={event => {

--- a/src/components/visual/SearchResult/service.tsx
+++ b/src/components/visual/SearchResult/service.tsx
@@ -46,9 +46,9 @@ const WrappedServiceTable: React.FC<Props> = ({ serviceResults, updates, setServ
             </DivTableRow>
           </DivTableHead>
           <DivTableBody>
-            {serviceResults.map(result => (
+            {serviceResults.map((result, i) => (
               <LinkRow
-                key={result.name}
+                key={`${result.name}-${i}`}
                 component={Link}
                 to={`/admin/services/${result.name}`}
                 hover

--- a/src/components/visual/SearchResult/submissions.tsx
+++ b/src/components/visual/SearchResult/submissions.tsx
@@ -70,7 +70,7 @@ const WrappedSubmissionsTable: React.FC<Props> = ({ submissionResults, allowSort
           <DivTableBody>
             {submissionResults.items.map((submission, id) => (
               <LinkRow
-                key={id}
+                key={`${submission.id}-${id}`}
                 component={Link}
                 to={
                   submission.state === 'completed'

--- a/src/components/visual/SearchResult/users.tsx
+++ b/src/components/visual/SearchResult/users.tsx
@@ -45,8 +45,13 @@ const WrappedUsersTable: React.FC<Props> = ({ userResults }) => {
             </DivTableRow>
           </DivTableHead>
           <DivTableBody>
-            {userResults.items.map(user => (
-              <LinkRow key={user.id} to={`/admin/users/${user.uname}`} hover style={{ textDecoration: 'none' }}>
+            {userResults.items.map((user, i) => (
+              <LinkRow
+                key={`${user.id}-${i}`}
+                to={`/admin/users/${user.uname}`}
+                hover
+                style={{ textDecoration: 'none' }}
+              >
                 <DivTableCell style={{ whiteSpace: 'nowrap' }}>{user.uname}</DivTableCell>
                 <DivTableCell>{user.name}</DivTableCell>
                 <DivTableCell>

--- a/src/components/visual/SearchResult/workflow.tsx
+++ b/src/components/visual/SearchResult/workflow.tsx
@@ -50,9 +50,9 @@ const WrappedWorflowTable: React.FC<Props> = ({ workflowResults, setWorkflowID =
             </DivTableRow>
           </DivTableHead>
           <DivTableBody>
-            {workflowResults.items.map(workflow => (
+            {workflowResults.items.map((workflow, i) => (
               <LinkRow
-                key={workflow.workflow_id}
+                key={`${workflow.workflow_id}-${i}`}
                 component={Link}
                 to={`/manage/workflow/detail/${workflow.workflow_id}`}
                 onClick={event => {

--- a/src/components/visual/Table/enhanced_table.tsx
+++ b/src/components/visual/Table/enhanced_table.tsx
@@ -333,6 +333,7 @@ const WrappedEnhancedTableBody: React.FC<EnhancedTableBodyProps> = ({
                 .map((row, index) =>
                   linkField && linkPrefix ? (
                     <LinkRow
+                      key={index}
                       hover
                       component={Link}
                       to={`${linkPrefix}${row[linkField]}`}
@@ -345,7 +346,6 @@ const WrappedEnhancedTableBody: React.FC<EnhancedTableBodyProps> = ({
                           : null
                       }
                       tabIndex={-1}
-                      key={index}
                     >
                       {cells.map(head => (
                         <DivTableCell


### PR DESCRIPTION
Improved the `key` prop definition in the TableRows to avoid reconciliation issues which prevents rows from rerendering if they have the identical keys.
