### PR TITLE
Bugfix/SearchResult (master)

### DIFF
--- a/src/components/routes/manage/heuristic_detail.tsx
+++ b/src/components/routes/manage/heuristic_detail.tsx
@@ -273,7 +273,7 @@ const HeuristicDetail = ({ heur_id = null }: HeuristicDetailProps) => {
                 <Typography variant="h6">{t('last10')}</Typography>
               </Grid>
               <Grid size={{ xs: 12 }}>
-                <ResultsTable resultResults={results} allowSort={false} />
+                <ResultsTable resultResults={results} allowSort={false} allowHash />
               </Grid>
             </>
           )}

--- a/src/components/routes/manage/signature_detail.tsx
+++ b/src/components/routes/manage/signature_detail.tsx
@@ -623,7 +623,7 @@ const SignatureDetail = ({
                 <Typography variant="h6">{t('last10')}</Typography>
               </Grid>
               <Grid size={{ xs: 12 }}>
-                <ResultsTable resultResults={results} allowSort={false} />
+                <ResultsTable resultResults={results} allowSort={false} allowHash />
               </Grid>
             </>
           )}

--- a/src/components/visual/ArchiveDetail/tags.tsx
+++ b/src/components/visual/ArchiveDetail/tags.tsx
@@ -607,7 +607,7 @@ const WrappedRow: React.FC<RowProps> = ({
           <Collapse in={open && resultResults?.total > 0} timeout="auto" onEnter={() => setRender(true)}>
             {render && (
               <div style={{ paddingTop: theme.spacing(2), paddingBottom: theme.spacing(2) }}>
-                <ResultsTable resultResults={resultResults} allowSort={false} />
+                <ResultsTable resultResults={resultResults} allowSort={false} allowHash />
               </div>
             )}
           </Collapse>

--- a/src/components/visual/SearchResult/results.tsx
+++ b/src/components/visual/SearchResult/results.tsx
@@ -27,9 +27,15 @@ type Props = {
   resultResults: SearchResult<ResultIndexed>;
   component?: React.ElementType;
   allowSort?: boolean;
+  allowHash?: boolean;
 };
 
-const WrappedResultsTable: React.FC<Props> = ({ resultResults, component = Paper, allowSort = true }) => {
+const WrappedResultsTable: React.FC<Props> = ({
+  resultResults,
+  component = Paper,
+  allowSort = true,
+  allowHash = false
+}) => {
   const { t } = useTranslation(['search']);
   const { c12nDef } = useALContext();
   const theme = useTheme();
@@ -69,7 +75,7 @@ const WrappedResultsTable: React.FC<Props> = ({ resultResults, component = Paper
               <LinkRow
                 key={`${result.id}-${id}`}
                 component={Link}
-                to={`/file/detail/${result.id.substring(0, 64)}${location.hash}`}
+                to={`/file/detail/${result.id.substring(0, 64)}${!allowHash ? null : location.hash}`}
                 hover
                 style={{ textDecoration: 'none' }}
               >


### PR DESCRIPTION
Added the `allowHash` prop to the ResultsTable to allow the propagation of the `location.hash` when clicking on a row.