### PR TITLE
UI/Changes (dev)

### DIFF
--- a/src/components/routes/retrohunt/detail.tsx
+++ b/src/components/routes/retrohunt/detail.tsx
@@ -264,10 +264,9 @@ function WrappedRetrohuntDetailPage({ search_key: propKey = null, isDrawer = fal
 
   const handleHitRowClick = useCallback(
     (file: FileIndexed) => {
-      if (isDrawer) navigate(`/file/detail/${file.sha256}${location.hash}`);
-      else navigate(`${location.pathname}${location.search}#${file.sha256}`);
+      navigate({ pathname: `/retrohunt/${searchKey}`, hash: file.sha256 });
     },
-    [isDrawer, location.hash, location.pathname, location.search, navigate]
+    [navigate, searchKey]
   );
 
   const handleRepeat = useCallback(


### PR DESCRIPTION
When clicking on a row in the RetrohuntDetail page's file hits table, it will open the RetrohuntDetail page on the left and the FileDetail in the drawer.