### PR TITLE
Fix file size display in submission report General Information

### DIFF
--- a/src/components/routes/submission/report/file_tree.tsx
+++ b/src/components/routes/submission/report/file_tree.tsx
@@ -44,7 +44,8 @@ function FileTree({ tree, important_files }: Props) {
                         }}
                       >
                         {`${tree[f].sha256} - ${tree[f].type} - `}
-                        <span style={{ fontWeight: 300 }}>{bytesToSize(tree[f].size)}</span>
+                        <b>{tree[f].size}</b>
+                        <span style={{ fontWeight: 300 }}> ({bytesToSize(tree[f].size)})</span>
                       </Box>
                     </td>
                   </tr>

--- a/src/components/routes/submission/report/file_tree.tsx
+++ b/src/components/routes/submission/report/file_tree.tsx
@@ -44,8 +44,7 @@ function FileTree({ tree, important_files }: Props) {
                         }}
                       >
                         {`${tree[f].sha256} - ${tree[f].type} - `}
-                        <b>{tree[f].size}</b>
-                        <span style={{ fontWeight: 300 }}> ({bytesToSize(tree[f].size)})</span>
+                        <span style={{ fontWeight: 300 }}>{bytesToSize(tree[f].size)}</span>
                       </Box>
                     </td>
                   </tr>

--- a/src/components/routes/submission/report/general_info.tsx
+++ b/src/components/routes/submission/report/general_info.tsx
@@ -283,7 +283,7 @@ function WrappedGeneralInformation({ report }: Props) {
                 {!report ? (
                   <Skeleton />
                 ) : !report?.file_info?.size ? null : (
-                  <span style={{ fontWeight: 500 }}>
+                  <span>
                     {report?.file_info?.size}
                     <span>{` (${bytesToSize(report?.file_info?.size)})`}</span>
                   </span>

--- a/src/components/routes/submission/report/general_info.tsx
+++ b/src/components/routes/submission/report/general_info.tsx
@@ -4,6 +4,7 @@ import type { SubmissionReport } from 'components/models/ui/submission_report';
 import Moment from 'components/visual/Moment';
 import { GraphBody } from 'components/visual/ResultCard/graph_body';
 import { ImageInlineBody } from 'components/visual/image_inline';
+import { bytesToSize } from 'helpers/utils';
 import type { ReactNode } from 'react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -278,7 +279,7 @@ function WrappedGeneralInformation({ report }: Props) {
               <Grid size={{ xs: 4, sm: 3, lg: 2 }}>
                 <span style={{ fontWeight: 500 }}>{t('file.size')}</span>
               </Grid>
-              <Grid size={{ xs: 8, sm: 9, lg: 10 }}>{report ? report?.file_info?.size : <Skeleton />}</Grid>
+              <Grid size={{ xs: 8, sm: 9, lg: 10 }}>{report ? bytesToSize(report?.file_info?.size) : <Skeleton />}</Grid>
 
               <Grid size={{ xs: 4, sm: 3, lg: 2 }}>
                 <span style={{ fontWeight: 500 }}>{t('file.md5')}</span>

--- a/src/components/routes/submission/report/general_info.tsx
+++ b/src/components/routes/submission/report/general_info.tsx
@@ -279,7 +279,7 @@ function WrappedGeneralInformation({ report }: Props) {
               <Grid size={{ xs: 4, sm: 3, lg: 2 }}>
                 <span style={{ fontWeight: 500 }}>{t('file.size')}</span>
               </Grid>
-              <Grid size={{ xs: 8, sm: 9, lg: 10 }}>{report ? bytesToSize(report?.file_info?.size) : <Skeleton />}</Grid>
+              <Grid size={{ xs: 8, sm: 9, lg: 10 }}>{report ? bytesToSize(report.file_info.size) : <Skeleton />}</Grid>
 
               <Grid size={{ xs: 4, sm: 3, lg: 2 }}>
                 <span style={{ fontWeight: 500 }}>{t('file.md5')}</span>

--- a/src/components/routes/submission/report/general_info.tsx
+++ b/src/components/routes/submission/report/general_info.tsx
@@ -279,7 +279,16 @@ function WrappedGeneralInformation({ report }: Props) {
               <Grid size={{ xs: 4, sm: 3, lg: 2 }}>
                 <span style={{ fontWeight: 500 }}>{t('file.size')}</span>
               </Grid>
-              <Grid size={{ xs: 8, sm: 9, lg: 10 }}>{report ? bytesToSize(report.file_info.size) : <Skeleton />}</Grid>
+              <Grid size={{ xs: 8, sm: 9, lg: 10 }}>
+                {!report ? (
+                  <Skeleton />
+                ) : !report?.file_info?.size ? null : (
+                  <span style={{ fontWeight: 500 }}>
+                    {report?.file_info?.size}
+                    <span>{` (${bytesToSize(report?.file_info?.size)})`}</span>
+                  </span>
+                )}
+              </Grid>
 
               <Grid size={{ xs: 4, sm: 3, lg: 2 }}>
                 <span style={{ fontWeight: 500 }}>{t('file.md5')}</span>


### PR DESCRIPTION
## Summary

File size fields in the submission report display raw bytes (e.g. `15732736`) instead of a human-readable format.

`bytesToSize` already exists in `helpers/utils.ts` and is used in parts of the codebase, but was not applied consistently in the submission report components.

## Changes

**`submission/report/general_info.tsx`**
- Import `bytesToSize` from `helpers/utils`
- Wrap `report.file_info.size` with `bytesToSize()` in the General Information size field

**`submission/report/file_tree.tsx`**
- Replace the raw byte value (bold) + formatted size (light span) pattern with a single `<span style={{ fontWeight: 300 }}>` wrapping `bytesToSize()`

## Before / After

| Location | Before | After |
|----------|--------|-------|
| General Information — Size | `15732736` | `15 MB` |
| File Tree — file metadata | `15732736 (15 MB)` | `15 MB` |