### PR TITLE
Dependencies/Quarantine (master)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   "version": "4.6.0",
   "license": "MIT",
   "private": true,
+  "config": {
+    "min-release-age": "3"
+  },
   "dependencies": {
     "@date-io/date-fns": "^3.2.1",
     "@emotion/react": "^11.14.0",


### PR DESCRIPTION
Added npm config set minimum-release-age 3 (often also set as min-release-age) enforces a quarantine period for newly published packages. It protects against supply chain attacks, where malicious code is often detected and removed from the registry within the first few hours or days of release.