### PR TITLE
UI/Changes (master)

### DIFF
--- a/src/components/visual/ActionMenu.tsx
+++ b/src/components/visual/ActionMenu.tsx
@@ -68,7 +68,7 @@ const categoryIndex = {
   hash: ''
 } as const;
 
-type ActionMenuProps = {
+export type ActionMenuProps = {
   category: 'heuristic' | 'signature' | 'hash' | 'metadata' | 'tag';
   index?: string;
   type: string;
@@ -76,6 +76,7 @@ type ActionMenuProps = {
   classification?: string | null;
   state: Coordinates;
   highlight_key?: string;
+  maliciousness?: 'suspicious' | 'malicious' | 'safe' | 'info' | 'highly_suspicious';
   setState: (coordinates: Coordinates) => void;
   setBorealisDetails?: (value: boolean) => void;
 };
@@ -89,6 +90,7 @@ const WrappedActionMenu = ({
   state,
   setState,
   highlight_key = null,
+  maliciousness = null,
   setBorealisDetails = null
 }: ActionMenuProps) => {
   const { t } = useTranslation();
@@ -444,7 +446,7 @@ const WrappedActionMenu = ({
             to={
               index
                 ? `/search${index}?query=${type}:${safeFieldValueURI(value)}`
-                : `/search${categoryIndex[category]}?query=${category === 'tag' && safelisted ? 'result.sections.safelisted_tags.' : categoryPrefix[category]}${type}:${safeFieldValueURI(
+                : `/search${categoryIndex[category]}?query=${category === 'tag' && maliciousness === 'safe' ? 'result.sections.safelisted_tags.' : categoryPrefix[category]}${type}:${safeFieldValueURI(
                     value
                   )}`
             }

--- a/src/components/visual/ActionMenu.tsx
+++ b/src/components/visual/ActionMenu.tsx
@@ -444,7 +444,7 @@ const WrappedActionMenu = ({
             to={
               index
                 ? `/search${index}?query=${type}:${safeFieldValueURI(value)}`
-                : `/search${categoryIndex[category]}?query=${categoryPrefix[category]}${type}:${safeFieldValueURI(
+                : `/search${categoryIndex[category]}?query=${category === 'tag' && safelisted ? 'result.sections.safelisted_tags.' : categoryPrefix[category]}${type}:${safeFieldValueURI(
                     value
                   )}`
             }

--- a/src/components/visual/Tag.tsx
+++ b/src/components/visual/Tag.tsx
@@ -2,6 +2,7 @@ import { HIDE_EVENT_ID } from 'borealis-ui/dist/data/event';
 import useALContext from 'components/hooks/useALContext';
 import useHighlighter from 'components/hooks/useHighlighter';
 import useSafeResults from 'components/hooks/useSafeResults';
+import type { ActionMenuProps } from 'components/visual/ActionMenu';
 import ActionMenu from 'components/visual/ActionMenu';
 import CustomChip from 'components/visual/CustomChip';
 import EnrichmentCustomChip, { BOREALIS_TYPE_MAP } from 'components/visual/EnrichmentCustomChip';
@@ -104,6 +105,7 @@ const WrappedTag: React.FC<TagProps> = ({
           setState={setState}
           classification={classification}
           highlight_key={highlight_key}
+          maliciousness={maliciousness as ActionMenuProps['maliciousness']}
           setBorealisDetails={setShowBorealisDetails}
         />
       )}


### PR DESCRIPTION
 - Ensure "Find related results" uses `safelisted_tags` instead of `tags` when the tag is safelisted, preventing empty search results.