### PR TITLE
When a URL is provided as input, use the appropriate field in the File index for matching on existing URIs

### DIFF
--- a/src/components/routes/submit/submit.utils.ts
+++ b/src/components/routes/submit/submit.utils.ts
@@ -419,7 +419,7 @@ export const calculateFileHash = (file: File): Promise<string> =>
  * @param value - Hash value.
  */
 export const getHashQuery = (type: string, value: string): string =>
-  type === 'file' ? `sha256:"${value}"` : `${type}:"${value}"`;
+  type === 'file' ? `sha256:"${value}"` : type === 'url' ? `uri_info.uri:"${value}"` : `${type}:"${value}"`;
 
 /**
  * @param settings - Profile settings.


### PR DESCRIPTION
Noticed this when updating the User Manual