### PR TITLE
nginx/gzip (dev)

### DIFF
--- a/docker/minimal.template
+++ b/docker/minimal.template
@@ -23,6 +23,7 @@ server {
     gzip_comp_level 5;
     gzip_min_length 1024;
     gzip_http_version 1.1;
+    gzip_disable "^(?!.*(Mozilla|AppleWebKit|Chrome|Safari|Windows|Macintosh|Linux))";
     gzip_types
         application/javascript
         application/json


### PR DESCRIPTION
Added `gzip_disable` to ignore all non-browser user-agents