### PR TITLE
Revert "Update relevant code to display JFrog as an registry type option (dev)"

### DIFF
--- a/src/components/models/base/config.ts
+++ b/src/components/models/base/config.ts
@@ -25,7 +25,7 @@ export const METADATA_FIELDTYPE_MAP = [
   'text',
   'uri'
 ] as const;
-export const REGISTRY_TYPES = ['docker', 'harbor', 'jfrog'] as const;
+export const REGISTRY_TYPES = ['docker', 'harbor'] as const;
 export const SAFELIST_HASH_TYPES = ['sha1', 'sha256', 'md5'] as const;
 export const SERVICE_CATEGORIES = [
   'Antivirus',

--- a/src/components/routes/admin/service_detail/container_dialog.tsx
+++ b/src/components/routes/admin/service_detail/container_dialog.tsx
@@ -467,8 +467,7 @@ const WrappedContainerDialog = ({
                 reset={showReset(tempContainer, defaults, 'registry_type')}
                 options={[
                   { value: 'docker', primary: t('Docker') },
-                  { value: 'harbor', primary: t('Harbor') },
-                  { value: 'jfrog', primary: t('JFrog') }
+                  { value: 'harbor', primary: t('Harbor') }
                 ]}
                 onChange={(e, v: string) => handleContainerValueChange('registry_type', v)}
               />


### PR DESCRIPTION
Reverts CybercentreCanada/assemblyline-ui-frontend#1959

Reverting changes since the change is no longer necessary since JFrog registries supports [Docker Registry HTTP API V2](https://distribution.github.io/distribution/spec/api/) so the `docker` registry type can be used in AL:
https://discord.com/channels/908084610158714900/909869835041787924/1513910826455666938